### PR TITLE
feat(controllers): Get before update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -1,0 +1,6 @@
+package options
+
+type Opts struct {
+	UpdateFQDNRetryTime      int
+	FQDNDnsLookupNextSyncMax int
+}

--- a/config/options/options.go
+++ b/config/options/options.go
@@ -1,6 +1,0 @@
-package options
-
-type Opts struct {
-	UpdateFQDNRetryTime      int
-	FQDNDnsLookupNextSyncMax int
-}

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -128,7 +128,7 @@ func (r *FQDNNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// It's probably related to the TTL of the DNS records.
 	nextSyncIn, err := r.updateNetworkPolicy(ctx, fqdnNetworkPolicy)
 	if err != nil {
-		log.Error(err, "unable to update NetworkPolicy")
+		log.Error(err, "could not update NetworkPolicy, "+fqdnNetworkPolicy.Name+" retrying in "+fmt.Sprint(r.Options.UpdateFQDNRetryTime)+" seconds")
 		// Need to fetch the object again before updating FQDNNetworkPolicy
 		if ee := r.Get(ctx, client.ObjectKey{
 			Namespace: req.Namespace,
@@ -143,7 +143,7 @@ func (r *FQDNNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		n := metav1.NewTime(time.Now().Add(retry))
 		fqdnNetworkPolicy.Status.NextSyncTime = &n
 		if e := r.Status().Update(ctx, fqdnNetworkPolicy); e != nil {
-			log.Error(e, "unable to update FQDNNetworkPolicy status")
+			log.Error(e, "unable to update pending FQDNNetworkPolicy status")
 			return ctrl.Result{}, e
 		}
 		return ctrl.Result{RequeueAfter: retry}, nil
@@ -167,7 +167,7 @@ func (r *FQDNNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Updating the status of our FQDNNetworkPolicy
 	if err := r.Status().Update(ctx, fqdnNetworkPolicy); err != nil {
-		log.Error(err, "unable to update FQDNNetworkPolicy status")
+		log.Error(err, "unable to update active FQDNNetworkPolicy status")
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -355,7 +355,7 @@ func (r *FQDNNetworkPolicyReconciler) getNetworkPolicyIngressRules(ctx context.C
 				// timeout the next etc. So this is not too bad for now.
 				r, _, err := c.Exchange(m, "["+ns[0]+"]:53")
 				if err != nil {
-					log.Error(err, "unable to resolve "+f)
+					log.V(1).Info("unable to resolve " + f + " " + err.Error())
 					continue
 				}
 				if len(r.Answer) == 0 {
@@ -388,7 +388,7 @@ func (r *FQDNNetworkPolicyReconciler) getNetworkPolicyIngressRules(ctx context.C
 				// timeout the next etc. So this is not too bad for now.
 				r6, _, err := c.Exchange(m6, "["+ns[0]+"]:53")
 				if err != nil {
-					log.Error(err, "unable to resolve "+f)
+					log.V(1).Info("unable to resolve " + f + " " + err.Error())
 					continue
 				}
 				if len(r6.Answer) == 0 {

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -131,8 +131,8 @@ func (r *FQDNNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		log.Error(err, "could not update NetworkPolicy, "+fqdnNetworkPolicy.Name+" retrying in "+fmt.Sprint(r.Options.UpdateFQDNRetryTime)+" seconds")
 		// Need to fetch the object again before updating FQDNNetworkPolicy
 		if ee := r.Get(ctx, client.ObjectKey{
-			Namespace: req.Namespace,
-			Name:      req.Name,
+			Namespace: fqdnNetworkPolicy.Namespace,
+			Name:      fqdnNetworkPolicy.Name,
 		}, fqdnNetworkPolicy); ee != nil {
 			log.Error(err, "unable to fetch FQDNNetworkPolicy")
 			return ctrl.Result{}, err

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -162,6 +162,7 @@ func (r *FQDNNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	fqdnNetworkPolicy.Status.State = networkingv1alpha3.ActiveState
+	fqdnNetworkPolicy.Status.Reason = "NetworkPolicy updated"
 	nextSyncTime := metav1.NewTime(time.Now().Add(*nextSyncIn))
 	fqdnNetworkPolicy.Status.NextSyncTime = &nextSyncTime
 

--- a/controllers/netpol.go
+++ b/controllers/netpol.go
@@ -1,0 +1,61 @@
+package controllers
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/api/v1alpha3"
+	"github.com/mitchellh/hashstructure/v2"
+	networking "k8s.io/api/networking/v1"
+)
+
+const (
+	ownerAnnotation = "fqdnnetworkpolicies.networking.gke.io/owned-by"
+)
+
+type Netpol struct {
+	*networking.NetworkPolicy
+}
+
+func (n *Netpol) UpdateMetadata(fqdn *v1alpha3.FQDNNetworkPolicy) {
+	n.Name = fqdn.Name
+	n.Namespace = fqdn.Namespace
+	if n.Annotations == nil {
+		n.Annotations = make(map[string]string)
+	}
+	n.Annotations[ownerAnnotation] = fqdn.Name
+	n.Spec.PodSelector = fqdn.Spec.PodSelector
+	n.Spec.PolicyTypes = fqdn.Spec.PolicyTypes
+}
+
+func (n *Netpol) UpdateEgress(fqdnEgress []networking.NetworkPolicyEgressRule) {
+	n.Spec.Egress = fqdnEgress
+}
+
+func (n *Netpol) UpdateIngress(fqdnIngress []networking.NetworkPolicyIngressRule) {
+	n.Spec.Ingress = fqdnIngress
+}
+
+func (n *Netpol) EgressRulesEquals(egress []networking.NetworkPolicyEgressRule) (bool, error) {
+	netpolHash, err := hashstructure.Hash(n.NetworkPolicy.Spec.Egress, hashstructure.FormatV2, nil)
+	if err != nil {
+		return false, err
+	}
+
+	currentHash, err := hashstructure.Hash(egress, hashstructure.FormatV2, nil)
+	if err != nil {
+		return false, err
+	}
+	return fmt.Sprintf("%x", netpolHash) == fmt.Sprintf("%x", currentHash), nil
+}
+
+func (n *Netpol) IngressRulesEquals(ingress []networking.NetworkPolicyIngressRule) (bool, error) {
+	netpolHash, err := hashstructure.Hash(n.NetworkPolicy.Spec.Ingress, hashstructure.FormatV2, nil)
+	if err != nil {
+		return false, err
+	}
+
+	currentHash, err := hashstructure.Hash(ingress, hashstructure.FormatV2, nil)
+	if err != nil {
+		return false, err
+	}
+	return fmt.Sprintf("%x", netpolHash) == fmt.Sprintf("%x", currentHash), nil
+}

--- a/controllers/netpol_test.go
+++ b/controllers/netpol_test.go
@@ -1,0 +1,141 @@
+package controllers
+
+import (
+	"github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/api/v1alpha3"
+	"github.com/stretchr/testify/assert"
+	networking "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+type TestCase struct {
+	currentFqdn       *v1alpha3.FQDNNetworkPolicy
+	foundEgressRules  []networking.NetworkPolicyEgressRule
+	foundIngressRules []networking.NetworkPolicyIngressRule
+}
+
+func TestNetpol(t *testing.T) {
+	tests := []struct {
+		name          string
+		testCase      TestCase
+		currentNetpol Netpol
+		shouldUpdate  bool
+	}{
+		{
+			name:          "should not update network policy",
+			testCase:      newTestCase("10.10", "10.10"),
+			currentNetpol: netPool("10.10", "10.10"),
+		}, {
+			name:          "found egress changed, should update network policy",
+			testCase:      newTestCase("10.10", "10.12"),
+			currentNetpol: netPool("10.10", "10.11"),
+			shouldUpdate:  true,
+		}, {
+			name:          "current netpol egress differs, should update network policy",
+			testCase:      newTestCase("10.10", "10.11"),
+			currentNetpol: netPool("10.10", "10.12"),
+			shouldUpdate:  true,
+		}, {
+			name:          "found ingress differs, should update network policy",
+			testCase:      newTestCase("10.11", "10.10"),
+			currentNetpol: netPool("10.10", "10.10"),
+			shouldUpdate:  true,
+		}, {
+			name:          "current netpol ingress differs, should update network policy",
+			testCase:      newTestCase("10.11", "10.10"),
+			currentNetpol: netPool("10.12", "10.10"),
+			shouldUpdate:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// check of network policy
+			tt.currentNetpol.UpdateMetadata(tt.testCase.currentFqdn)
+			assert.Equal(t, tt.testCase.currentFqdn.Name, tt.currentNetpol.Name)
+			assert.Equal(t, tt.testCase.currentFqdn.Namespace, tt.currentNetpol.Namespace)
+			assert.Equal(t, tt.testCase.currentFqdn.Annotations, tt.currentNetpol.Annotations)
+			assert.Equal(t, tt.testCase.currentFqdn.Spec.PodSelector, tt.currentNetpol.Spec.PodSelector)
+			assert.Equal(t, tt.testCase.currentFqdn.Spec.PolicyTypes, tt.currentNetpol.Spec.PolicyTypes)
+
+			if tt.shouldUpdate {
+				tt.currentNetpol.UpdateEgress(tt.testCase.foundEgressRules)
+				tt.currentNetpol.UpdateIngress(tt.testCase.foundIngressRules)
+				assert.Equal(t, tt.testCase.foundEgressRules, tt.currentNetpol.Spec.Egress)
+				assert.Equal(t, tt.testCase.foundIngressRules, tt.currentNetpol.Spec.Ingress)
+			}
+		})
+	}
+}
+
+func newTestCase(ingressCidr, egressCidr string) TestCase {
+	return TestCase{
+		currentFqdn: &v1alpha3.FQDNNetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "my-fqdn",
+				Namespace: "default",
+				Annotations: map[string]string{
+					ownerAnnotation: "my-fqdn",
+				},
+			},
+			Spec: v1alpha3.FQDNNetworkPolicySpec{
+				PolicyTypes: []networking.PolicyType{
+					networking.PolicyTypeEgress,
+				},
+				Egress: []v1alpha3.FQDNNetworkPolicyEgressRule{
+					{
+						To: []v1alpha3.FQDNNetworkPolicyPeer{
+							{
+								FQDNs: []string{"my-fqdn"},
+							},
+						},
+					},
+				},
+			},
+		},
+		foundEgressRules:  egress(egressCidr),
+		foundIngressRules: ingress(ingressCidr),
+	}
+}
+
+func ingress(cidr string) []networking.NetworkPolicyIngressRule {
+	return []networking.NetworkPolicyIngressRule{
+		{
+			From: []networking.NetworkPolicyPeer{
+				{
+					IPBlock: &networking.IPBlock{
+						CIDR: cidr,
+					},
+				},
+			},
+		},
+	}
+}
+
+func egress(cidr string) []networking.NetworkPolicyEgressRule {
+	return []networking.NetworkPolicyEgressRule{
+		{
+			To: []networking.NetworkPolicyPeer{
+				{
+					IPBlock: &networking.IPBlock{
+						CIDR: cidr,
+					},
+				},
+			},
+		},
+	}
+}
+
+func netPool(ingressCidr, egressCidr string) Netpol {
+	return Netpol{
+		NetworkPolicy: &networking.NetworkPolicy{
+			Spec: networking.NetworkPolicySpec{
+				PolicyTypes: []networking.PolicyType{
+					networking.PolicyTypeEgress,
+				},
+				Egress:  egress(egressCidr),
+				Ingress: ingress(ingressCidr),
+			},
+		},
+	}
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/config/options"
 	"path/filepath"
 	"testing"
 	"time"
@@ -80,9 +81,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&FQDNNetworkPolicyReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("FQDNNetworkPolicy"),
+		Client:  k8sManager.GetClient(),
+		Scheme:  k8sManager.GetScheme(),
+		Log:     ctrl.Log.WithName("controllers").WithName("FQDNNetworkPolicy"),
+		Options: options.Opts{UpdateFQDNRetryTime: 1, FQDNDnsLookupNextSyncMax: 10},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/config/options"
 	"path/filepath"
 	"testing"
 	"time"
@@ -84,7 +83,7 @@ var _ = BeforeSuite(func(done Done) {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Log:     ctrl.Log.WithName("controllers").WithName("FQDNNetworkPolicy"),
-		Options: options.Opts{UpdateFQDNRetryTime: 1, FQDNDnsLookupNextSyncMax: 10},
+		Options: Opts{UpdateFQDNRetryTime: 1, FQDNDnsLookupNextSyncMax: 10},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.20
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/miekg/dns v1.1.54
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.7
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.10.0
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
@@ -43,6 +45,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.1.54 h1:5jon9mWcb0sFJGpnI99tOMhCPyJ+RPVz5b63MQG0VWI=
 github.com/miekg/dns v1.1.54/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&op.UpdateFQDNRetryTime, "reconcile-retry-time", 10, "The time in seconds to wait before retrying to update FQDNNetworkPolicy")
+	flag.IntVar(&op.UpdateFQDNRetryTime, "update-fqdn-retry-time", 10, "The time in seconds to wait before retrying to update FQDNNetworkPolicy")
 	flag.IntVar(&op.FQDNDnsLookupNextSyncMax, "fqdn-dns-lookup-next-sync-max", 30, "The maximum time to wait for FQDNNetworkPolicy next lookup in a single sync")
 	opts := zap.Options{
 		Development: true,

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/config/options"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -53,14 +52,14 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var op options.Opts
+	var op controllers.Opts
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&op.UpdateFQDNRetryTime, "update-fqdn-retry-time", 10, "The time in seconds to wait before retrying to update FQDNNetworkPolicy")
-	flag.IntVar(&op.FQDNDnsLookupNextSyncMax, "fqdn-dns-lookup-next-sync-max", 30, "The maximum time to wait for FQDNNetworkPolicy next lookup in a single sync")
+	flag.IntVar(&op.UpdateFQDNRetryTime, "update-fqdn-retry-time", 15, "The time in seconds to wait before retrying to update FQDNNetworkPolicy")
+	flag.IntVar(&op.FQDNDnsLookupNextSyncMax, "fqdn-dns-lookup-next-sync-max", 60, "The maximum time to wait for FQDNNetworkPolicy next lookup in a single sync")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
* this can be handled by getting before updating, to be make sure your dealing with the latest object.

* add options tuning, by beeing able to sett retry time in secounds when an NetworkPolicy update goes error prune. Default was 10 sec.

* add options to configure Highest resync time for FQDNNetworkPolicy, default was 30 sec.

Note. Application checks both egress and ingress rules and sync will happen just after the TTL of the DNS record has expired. Applications pics lowest of them 2 and sets it as resync value.